### PR TITLE
Removed styling that should be added in main.css

### DIFF
--- a/styles/tables.css
+++ b/styles/tables.css
@@ -1,14 +1,17 @@
+/* 
+Madeline is going to do all of our formal centering in main.css
+
 .header__title {
   text-align: center;
 }
 
-.navigation {
+/* .navigation {
   text-align: center;
 }
 
 .page__header {
   text-align: center;
-}
+} */
 
 /* 
 Tables does not currently have a description. 


### PR DESCRIPTION
Hello again, just make sure I've commented out the extraneous centering key:value pairs in tables.css

## Steps to Test

1. Pull this branch gqg-tables-3
2. Open in Chrome, serve
3. Verify that styling has been removed in tables.css

Thanks!